### PR TITLE
Merge pull request #19 from akirachix/develop

### DIFF
--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Python environment
         uses: actions/setup-python@v4
         with:
-          python-version: 3.12
+          python-version: 3.11
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
# Description

## What is this?

This PR updates the GitHub Actions workflow to use **Python 3.11** instead of the previously specified **Python 3.8.10**, which is no longer available for `ubuntu-24.04` runners.

## Why this?

Python 3.8 reached end-of-life (EOL) in October 2024 and is no longer officially supported or built for newer operating systems like Ubuntu 24.04. Attempting to use `3.8.10` on `ubuntu-24.04` results in a workflow failure:

> `Error: The version '3.8.10' with architecture 'x64' was not found for Ubuntu 24.04.`

Upgrading to Python 3.11 ensures:
- Continued CI/CD pipeline functionality
- Better performance, security, and language features
- Long-term maintainability and compatibility with modern dependencies

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Optimization
- [x] Improvement

---

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas *(N/A — no app code changed)*
- [ ] I have made corresponding changes to the documentation 
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
