### PR TITLE
Develop

### DIFF
--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Set Heroku buildpack
         run: |
-          heroku buildpacks:set heroku/python -a zenoai
+          heroku buildpacks:set heroku/python -a zeno-ai
         env:
           HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
 


### PR DESCRIPTION
#  Fix Heroku App Name in CI: `zenoai` to `zeno-ai`

##  What is this?

This PR updates the Heroku app name in our GitHub Actions CI workflow from `zenoai` to `zeno-ai` to match the **actual app name** in Heroku.

Previously, the workflow was trying to set the buildpack on a non-existent app `zenoai`.

##  Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Improvement

#  Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code
- [ ] I have made corresponding changes to the documentation 
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes *(N/A — no app code changed)*
- [x] Any dependent changes have been merged and published in downstream modules
