### PR TITLE
Develop

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -78,7 +78,13 @@ class RunOutputArtifactSerializer(serializers.ModelSerializer):
 
 class RunSerializer(serializers.ModelSerializer):
     input_files = RunInputFileSerializer(many=True, read_only=True)
-    output_artifacts = RunOutputArtifactSerializer(many=True, read_only=True) 
+    output_artifacts = RunOutputArtifactSerializer(many=True, read_only=True)
+    conversation_id = serializers.PrimaryKeyRelatedField(
+        source = "conversation",
+        queryset=Conversation.objects.all(),
+        required=False,
+        allow_null=True
+    ) 
 
     class Meta:
         model = Run
@@ -138,4 +144,12 @@ class StepSerializer(serializers.ModelSerializer):
             })
 
         return data
+
+
+class ConversationWithRunsSerializer(serializers.ModelSerializer):
+    runs = RunSerializer(many=True, read_only=True)
+
+    class Meta:
+        model = Conversation
+        fields = ['conversation_id', 'title', 'created_at', 'runs']
 


### PR DESCRIPTION
## Description

This PR addresses the following changes:
- Fixed the `conversations` and `runs` serializers, ensuring correct linking between users, conversations, and runs.
- Created a new endpoint: `conversations/with_runs`, which allows users to access runs related to their conversations.
- Corrected the relationship so that runs are now properly linked to conversations via a foreign key, and users can access runs through conversations.
- Previously, runs were incorrectly linked directly to users, but now the linkage reflects the intended data model: users -> conversations -> runs.

### Motivation & Context
This change resolves issues with data integrity and access patterns for runs and conversations. The motivation is to ensure users can fetch their runs via conversations and to expose a convenient API endpoint for this use case.

---

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Optimization
- [ ] Improvement

---

## How Has This Been Tested?

- **Test A:** Manually tested user creation and verified runs are accessible via the new endpoint.
- **Test B:** Ran unit tests for serializers and endpoint logic.

---

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
